### PR TITLE
[WIP] Add the cascade option to relationships

### DIFF
--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytoone.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytoone.xml.php
@@ -1,3 +1,6 @@
 <many-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" inversed-by="<?php echo $fromPluralHandle; ?>">
+    <cascade>
+        <cascade-all/>
+    </cascade>
     <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
 </many-to-one>

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetomany.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetomany.xml.php
@@ -1,1 +1,5 @@
-<one-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" mapped-by="<?php echo $fromHandle; ?>" />
+<one-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" mapped-by="<?php echo $fromHandle; ?>">
+    <cascade>
+        <cascade-all/>
+    </cascade>
+</one-to-many>

--- a/test/unit/FieldType/Relationship/Generator/DoctrineManyToOneGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/DoctrineManyToOneGeneratorTest.php
@@ -140,9 +140,17 @@ class DoctrineManyToOneGeneratorTest extends TestCase
         );
         $this->assertNotEmpty($generated);
         $this->assertInstanceOf(Template::class, $generated);
-        $this->assertStringStartsWith(
-            '<many-to-one field="that_123" target-entity="nameFromSpace\Entity\ToBeMapped" inversed-by="mappers_37">',
-            (string) $generated
-        );
+
+        $expected = <<<EOT
+<many-to-one field="that_123" target-entity="nameFromSpace\Entity\ToBeMapped" inversed-by="mappers_37">
+    <cascade>
+        <cascade-all/>
+    </cascade>
+    <join-column name="that_123_id" referenced-column-name="id" />
+</many-to-one>
+
+EOT;
+
+        $this->assertEquals($expected, (string)$generated);
     }
 }

--- a/test/unit/FieldType/Relationship/Generator/DoctrineOneToManyGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/DoctrineOneToManyGeneratorTest.php
@@ -142,7 +142,11 @@ class DoctrineOneToManyGeneratorTest extends TestCase
         $this->assertInstanceOf(Template::class, $generated);
 
         $expected = <<<EOT
-<one-to-many field="thats_666" target-entity="nameFromSpace\Entity\ToBeMapped" mapped-by="mapper" />
+<one-to-many field="thats_666" target-entity="nameFromSpace\Entity\ToBeMapped" mapped-by="mapper">
+    <cascade>
+        <cascade-all/>
+    </cascade>
+</one-to-many>
 
 EOT;
 


### PR DESCRIPTION
[Don't merge this yet. There might be another, better, solution for the import where the cascade option should be omitted]

In order to be able to import a collection of entities with children, the cascade option was added to one-to-many and many-to-one relationships. This way, children are persisted to the database while persisting the parent.