### PR TITLE
Allow persisting entities without immediately flushing them

### DIFF
--- a/src/SectionField/Service/DoctrineSectionCreator.php
+++ b/src/SectionField/Service/DoctrineSectionCreator.php
@@ -37,6 +37,17 @@ class DoctrineSectionCreator implements CreateSectionInterface
         $this->entityManager->flush();
     }
 
+    public function persist(CommonSectionInterface $data, array $jitRelationships = null)
+    {
+        $this->setReferencesForJitRelationships($data, $jitRelationships);
+        $this->entityManager->persist($data);
+    }
+
+    public function flush()
+    {
+        $this->entityManager->flush();
+    }
+
     /**
      * Jit relationships are introduced due to the inability of symfony forms
      * to update a relationship by it's ID. It requires you to use the EntityType

--- a/test/unit/SectionField/Service/DoctrineSectionCreatorTest.php
+++ b/test/unit/SectionField/Service/DoctrineSectionCreatorTest.php
@@ -66,4 +66,48 @@ final class DoctrineSectionCreatorTest extends TestCase
 
         $section->save($data, [$jit]);
     }
+
+    /**
+     * @test
+     * @covers ::persist
+     */
+    public function it_persists()
+    {
+        $className = FullyQualifiedClassName::fromString('I am qualified! In a Class!');
+        $id = Id::fromInt(2222);
+        $data = Mockery::mock('alias:Tardigrades\SectionField\Generator\CommonSectionInterface')->makePartial();
+
+        $jit = Mockery::mock(JitRelationship::fromFullyQualifiedClassNameAndId($className, $id))->makePartial();
+        $jit->shouldReceive('getFullyQualifiedClassName')->andReturn($className);
+        $jit->shouldReceive('getId')->andReturn($id);
+
+        $section = new DoctrineSectionCreator($this->entityManager);
+
+        $this->entityManager->shouldReceive('getReference')
+            ->once()
+            ->with((string) $className, $id->toInt());
+
+        $this->entityManager->shouldReceive('persist')
+            ->once()
+            ->with($data);
+
+        $this->entityManager->shouldReceive('flush')
+            ->never();
+
+        $section->persist($data, [$jit]);
+    }
+
+    /**
+     * @test
+     * @covers ::flush
+     */
+    public function it_flushes()
+    {
+        $section = new DoctrineSectionCreator($this->entityManager);
+
+        $this->entityManager->shouldReceive('flush')
+            ->once();
+
+        $section->flush();
+    }
 }


### PR DESCRIPTION
Implements dionsnoeijen/sexy-field#57.