### PR TITLE
Finetune relationships

### DIFF
--- a/src/FieldType/Relationship/Generator/DoctrineManyToManyGenerator.php
+++ b/src/FieldType/Relationship/Generator/DoctrineManyToManyGenerator.php
@@ -54,6 +54,7 @@ class DoctrineManyToManyGenerator implements GeneratorInterface
                     (string) $templateDir . '/GeneratorTemplate/doctrine.manytomany.xml.php',
                     [
                         'type' => $fieldConfig['field']['relationship-type'],
+                        'owner' => $fieldConfig['field']['owner'],
                         'toPluralHandle' => Inflector::pluralize(
                             $fieldConfig['field']['to']
                         ) . $toVersion,

--- a/src/FieldType/Relationship/Generator/DoctrineManyToOneGenerator.php
+++ b/src/FieldType/Relationship/Generator/DoctrineManyToOneGenerator.php
@@ -43,6 +43,7 @@ class DoctrineManyToOneGenerator implements GeneratorInterface
             $from = $sectionManager->readByHandle($handle);
 
             /** @var SectionInterface $to */
+            $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
             $to = $sectionManager->readByHandle(Handle::fromString($fieldConfig['field']['to']));
 
             $fromVersion = $from->getVersion()->toInt() > 1 ? ('_' . $from->getVersion()->toInt()) : '';
@@ -52,7 +53,8 @@ class DoctrineManyToOneGenerator implements GeneratorInterface
                 TemplateLoader::load(
                     (string) $templateDir . '/GeneratorTemplate/doctrine.manytoone.xml.php',
                     [
-                        'toHandle' => $fieldConfig['field']['to'] . $toVersion,
+                        'type' => $fieldConfig['field']['relationship-type'],
+                        'toHandle' => $toHandle . $toVersion,
                         'toFullyQualifiedClassName' => $to->getConfig()->getFullyQualifiedClassName(),
                         'fromPluralHandle' => Inflector::pluralize((string) $handle) . $fromVersion,
                     ]

--- a/src/FieldType/Relationship/Generator/DoctrineOneToOneGenerator.php
+++ b/src/FieldType/Relationship/Generator/DoctrineOneToOneGenerator.php
@@ -49,6 +49,7 @@ class DoctrineOneToOneGenerator implements GeneratorInterface
             $from = $sectionManager->readByHandle($sectionConfig->getHandle());
 
             /** @var SectionInterface $to */
+            $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
             $to = $sectionManager->readByHandle(Handle::fromString($fieldConfig['field']['to']));
 
             $fromVersion = $from->getVersion()->toInt() > 1 ? ('_' . $from->getVersion()->toInt()) : '';
@@ -59,10 +60,11 @@ class DoctrineOneToOneGenerator implements GeneratorInterface
                     (string) $templateDir . '/GeneratorTemplate/doctrine.onetoone.xml.php',
                     [
                         'type' => $fieldConfig['field']['relationship-type'],
+                        'owner' => $fieldConfig['field']['owner'],
                         'toFullyQualifiedClassName' => $to->getConfig()->getFullyQualifiedClassName(),
                         'fromHandle' => $sectionConfig->getHandle() . $fromVersion,
                         'fromFullyQualifiedClassName' => $sectionConfig->getFullyQualifiedClassName(),
-                        'toHandle' => $fieldConfig['field']['to'] . $toVersion
+                        'toHandle' => $toHandle . $toVersion
                     ]
                 )
             );

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytomany.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytomany.xml.php
@@ -1,4 +1,20 @@
 <?php if ($type === 'unidirectional') { ?>
+<many-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>">
+    <cascade>
+        <cascade-all/>
+    </cascade>
+    <join-table name="<?php echo $fromPluralHandle; ?>_<?php echo $toPluralHandle; ?>">
+        <join-columns>
+            <join-column name="<?php echo $fromHandle; ?>_id" referenced-column-name="id" />
+        </join-columns>
+        <inverse-join-columns>
+            <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
+        </inverse-join-columns>
+    </join-table>
+</many-to-many>
+<?php } ?>
+
+<?php if ($type === 'bidirectional' && $owner) { ?>
 <many-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" inversed-by="<?php echo $fromPluralHandle; ?>">
     <cascade>
         <cascade-all/>
@@ -14,6 +30,6 @@
 </many-to-many>
 <?php } ?>
 
-<?php if ($type === 'bidirectional') { ?>
+<?php if ($type === 'bidirectional' && !$owner) { ?>
 <many-to-many field="<?php echo $toPluralHandle; ?>" mapped-by="<?php echo $fromPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>"/>
 <?php } ?>

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytoone.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytoone.xml.php
@@ -1,3 +1,11 @@
+<?php if ($type === 'bidirectional') { ?>
 <many-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" inversed-by="<?php echo $fromPluralHandle; ?>">
     <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
 </many-to-one>
+<?php } ?>
+
+<?php if ($type === 'unidirectional') { ?>
+<many-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>">
+    <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
+</many-to-one>
+<?php } ?>

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetoone.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetoone.xml.php
@@ -1,9 +1,15 @@
-<?php if ($type === 'inverseSide') { ?>
+<?php if ($type === 'bidirectional' && !$owner) { ?>
 <one-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" mapped-by="<?php echo $fromHandle; ?>" />
 <?php } ?>
 
-<?php if ($type === 'owningSide') { ?>
+<?php if ($type === 'bidirectional' && $owner) { ?>
 <one-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" inversed-by="<?php echo $fromHandle; ?>">
-  <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
+    <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
+</one-to-one>
+<?php } ?>
+
+<?php if ($type === 'unidirectional') { ?>
+<one-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>">
+   <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
 </one-to-one>
 <?php } ?>

--- a/test/unit/FieldType/Relationship/Generator/DoctrineManyToManyGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/DoctrineManyToManyGeneratorTest.php
@@ -62,7 +62,7 @@ final class DoctrineManyToManyGeneratorTest extends TestCase
      * @test
      * @covers ::generate
      */
-    public function it_generates_a_proper_template_too()
+    public function it_generates_a_proper_template_for_bidirectional_and_owner()
     {
         $fieldArrayThing = [
             'field' =>
@@ -70,10 +70,11 @@ final class DoctrineManyToManyGeneratorTest extends TestCase
                     'name' => 'iets',
                     'handle' => 'some handle',
                     'kind' => DoctrineManyToManyGenerator::KIND,
+                    'relationship-type' => 'bidirectional',
+                    'owner' => true,
                     'from' => 'this',
                     'to' => 'that',
-                    'type' => 'my type',
-                    'relationship-type' => 'unidirectional'
+                    'type' => 'my type'
                 ]
         ];
         $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
@@ -139,11 +140,230 @@ final class DoctrineManyToManyGeneratorTest extends TestCase
             TemplateDir::fromString('src/FieldType/Relationship'),
             $options
         );
+
+        $expected = <<<'EOT'
+
+<many-to-many field="thats_123" target-entity="nameFromSpace\Entity\ToBeMapped" inversed-by="mappers_37">
+    <cascade>
+        <cascade-all/>
+    </cascade>
+    <join-table name="mappers_37_thats_123">
+        <join-columns>
+            <join-column name="mapper_37_id" referenced-column-name="id" />
+        </join-columns>
+        <inverse-join-columns>
+            <join-column name="that_123_id" referenced-column-name="id" />
+        </inverse-join-columns>
+    </join-table>
+</many-to-many>
+
+
+EOT;
+
         $this->assertNotEmpty($generated);
         $this->assertInstanceOf(Template::class, $generated);
-        $this->assertStringStartsWith(
-            '<many-to-many field="thats_123" target-entity="nameFromSpace\Entity\ToBeMapped" inversed-by="mappers_37">',
-            (string) $generated
+        $this->assertSame($expected, (string) $generated);
+    }
+
+    /**
+     * @test
+     * @covers ::generate
+     */
+    public function it_generates_a_proper_template_for_bidirectional_and_not_owner()
+    {
+        $fieldArrayThing = [
+            'field' =>
+                [
+                    'name' => 'iets',
+                    'handle' => 'some handle',
+                    'kind' => DoctrineManyToManyGenerator::KIND,
+                    'relationship-type' => 'bidirectional',
+                    'owner' => false,
+                    'from' => 'this',
+                    'to' => 'that',
+                    'type' => 'my type'
+                ]
+        ];
+        $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
+
+        $field = Mockery::mock(new Field())
+            ->shouldDeferMissing()
+            ->shouldReceive('getConfig')
+            ->andReturn($fieldConfig)
+            ->getMock();
+
+        $doctrineSectionManager = Mockery::mock(SectionManagerInterface::class);
+        $fromSectionInterface = Mockery::mock(SectionInterface::class);
+        $toSectionInterface = Mockery::mock(SectionInterface::class);
+
+        $doctrineSectionManager->shouldReceive('readByHandle')
+            ->once()
+            ->andReturn($fromSectionInterface);
+
+        $doctrineSectionManager->shouldReceive('readByHandle')
+            ->once()
+            ->andReturn($toSectionInterface);
+
+        $fromSectionInterface->shouldReceive('getVersion')
+            ->twice()
+            ->andReturn(Version::fromInt(37));
+
+        $toSectionInterface->shouldReceive('getVersion')
+            ->twice()
+            ->andReturn(Version::fromInt(123));
+
+        $toSectionConfig =
+            SectionConfig::fromArray(
+                [
+                    'section' => [
+                        'name' => 'nameTo',
+                        'handle' => 'ToBeMapped',
+                        'fields' => ['a', 'b'],
+                        'default' => 'default',
+                        'namespace' => 'nameFromSpace'
+                    ]
+                ]
+            );
+
+        $toSectionInterface->shouldReceive('getConfig')
+            ->once()
+            ->andReturn($toSectionConfig);
+
+        $options = [
+            'sectionManager' => $doctrineSectionManager,
+            'sectionConfig' => SectionConfig::fromArray([
+                'section' => [
+                    'name' => 'iets',
+                    'handle' => 'mapper',
+                    'fields' => ['a', 'v', 'b'],
+                    'default' => 'def',
+                    'namespace' => 'nameInSpace'
+                ]
+            ])
+        ];
+
+        $generated = DoctrineManyToManyGenerator::generate(
+            $field,
+            TemplateDir::fromString('src/FieldType/Relationship'),
+            $options
         );
+
+        $expected = <<<'EOT'
+
+
+<many-to-many field="thats_123" mapped-by="mappers_37" target-entity="nameFromSpace\Entity\ToBeMapped"/>
+
+EOT;
+
+        $this->assertNotEmpty($generated);
+        $this->assertInstanceOf(Template::class, $generated);
+        $this->assertSame($expected, (string) $generated);
+    }
+
+    /**
+     * @test
+     * @covers ::generate
+     */
+    public function it_generates_a_proper_template_for_unidirectional()
+    {
+        $fieldArrayThing = [
+            'field' =>
+                [
+                    'name' => 'iets',
+                    'handle' => 'some handle',
+                    'kind' => DoctrineManyToManyGenerator::KIND,
+                    'relationship-type' => 'unidirectional',
+                    'owner' => true,
+                    'from' => 'this',
+                    'to' => 'that',
+                    'type' => 'my type'
+                ]
+        ];
+        $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
+
+        $field = Mockery::mock(new Field())
+            ->shouldDeferMissing()
+            ->shouldReceive('getConfig')
+            ->andReturn($fieldConfig)
+            ->getMock();
+
+        $doctrineSectionManager = Mockery::mock(SectionManagerInterface::class);
+        $fromSectionInterface = Mockery::mock(SectionInterface::class);
+        $toSectionInterface = Mockery::mock(SectionInterface::class);
+
+        $doctrineSectionManager->shouldReceive('readByHandle')
+            ->once()
+            ->andReturn($fromSectionInterface);
+
+        $doctrineSectionManager->shouldReceive('readByHandle')
+            ->once()
+            ->andReturn($toSectionInterface);
+
+        $fromSectionInterface->shouldReceive('getVersion')
+            ->twice()
+            ->andReturn(Version::fromInt(37));
+
+        $toSectionInterface->shouldReceive('getVersion')
+            ->twice()
+            ->andReturn(Version::fromInt(123));
+
+        $toSectionConfig =
+            SectionConfig::fromArray(
+                [
+                    'section' => [
+                        'name' => 'nameTo',
+                        'handle' => 'ToBeMapped',
+                        'fields' => ['a', 'b'],
+                        'default' => 'default',
+                        'namespace' => 'nameFromSpace'
+                    ]
+                ]
+            );
+
+        $toSectionInterface->shouldReceive('getConfig')
+            ->once()
+            ->andReturn($toSectionConfig);
+
+        $options = [
+            'sectionManager' => $doctrineSectionManager,
+            'sectionConfig' => SectionConfig::fromArray([
+                'section' => [
+                    'name' => 'iets',
+                    'handle' => 'mapper',
+                    'fields' => ['a', 'v', 'b'],
+                    'default' => 'def',
+                    'namespace' => 'nameInSpace'
+                ]
+            ])
+        ];
+
+        $generated = DoctrineManyToManyGenerator::generate(
+            $field,
+            TemplateDir::fromString('src/FieldType/Relationship'),
+            $options
+        );
+
+        $expected = <<<'EOT'
+<many-to-many field="thats_123" target-entity="nameFromSpace\Entity\ToBeMapped">
+    <cascade>
+        <cascade-all/>
+    </cascade>
+    <join-table name="mappers_37_thats_123">
+        <join-columns>
+            <join-column name="mapper_37_id" referenced-column-name="id" />
+        </join-columns>
+        <inverse-join-columns>
+            <join-column name="that_123_id" referenced-column-name="id" />
+        </inverse-join-columns>
+    </join-table>
+</many-to-many>
+
+
+
+EOT;
+
+        $this->assertNotEmpty($generated);
+        $this->assertInstanceOf(Template::class, $generated);
+        $this->assertSame($expected, (string) $generated);
     }
 }

--- a/test/unit/SectionField/Generator/DoctrineConfigGeneratorTest.php
+++ b/test/unit/SectionField/Generator/DoctrineConfigGeneratorTest.php
@@ -97,7 +97,8 @@ final class DoctrineConfigGeneratorTest extends TestCase
                     'fullyQualifiedClassName' => FullyQualifiedClassName::fromString(
                         '\\My\\Namespace\\FieldTypeClassOne'
                     ),
-                    'relationship-type' => 'unidirectional'
+                    'relationship-type' => 'unidirectional',
+                    'owner' => true
                 ]
             ]
         ];
@@ -119,10 +120,32 @@ final class DoctrineConfigGeneratorTest extends TestCase
             ->andReturn($fieldType);
 
         $writable = $this->generator->generateBySection($sectionOne);
+
+        //@codingStandardsIgnoreStart
+        $expected = <<<'EOT'
+<?xml version="1.0"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+  <entity name="My\Namespace\Entity\SectionOne" table="sectionOne">
+    <lifecycle-callbacks>
+      <lifecycle-callback type="prePersist" method="onPrePersist"/>
+      <lifecycle-callback type="preUpdate" method="onPreUpdate"/>
+    </lifecycle-callbacks>
+    <id name="id" type="integer">
+      <generator strategy="AUTO"/>
+    </id>
+    <one-to-one field="sectionTwo" target-entity="My\Namespace\Entity\SectionOne">
+      <join-column name="sectionTwo_id" referenced-column-name="id"/>
+    </one-to-one>
+  </entity>
+</doctrine-mapping>
+
+EOT;
+        //@codingStandardsIgnoreEnd
+
         $this->assertInstanceOf(Writable::class, $writable);
         $this->assertSame("My\\Namespace\\Resources\\config\\doctrine\\", $writable->getNamespace());
         $this->assertSame("SectionOne.orm.xml", $writable->getFilename());
-        $this->assertSame($this->givenXmlResult(), $writable->getTemplate());
+        $this->assertSame($expected, $writable->getTemplate());
         $this->assertCount(0, $this->generator->getBuildMessages());
     }
 
@@ -163,7 +186,8 @@ final class DoctrineConfigGeneratorTest extends TestCase
                     'fullyQualifiedClassName' => FullyQualifiedClassName::fromString(
                         '\\My\\Namespace\\FieldTypeClassOne'
                     ),
-                    'relationship-type' => 'unidirectional'
+                    'relationship-type' => 'unidirectional',
+                    'owner' => true
                 ]
             ]
         ];
@@ -224,7 +248,8 @@ final class DoctrineConfigGeneratorTest extends TestCase
                     'fullyQualifiedClassName' => FullyQualifiedClassName::fromString(
                         '\\My\\Namespace\\FieldTypeClassOne'
                     ),
-                    'relationship-type' => 'unidirectional'
+                    'relationship-type' => 'unidirectional',
+                    'owner' => true
                 ]
             ]
         ];
@@ -295,7 +320,8 @@ final class DoctrineConfigGeneratorTest extends TestCase
                 'handle' => $fieldHandle,
                 'kind' => $kind,
                 'to' => 'section' . $to,
-                'relationship-type' => 'unidirectional'
+                'relationship-type' => 'unidirectional',
+                'owner' => true
             ]
         ]);
 


### PR DESCRIPTION
Relationships can either be unidirectional (only defined at the owning side) or bidirectional.
For the latter a new config option was introduced: owner. The templates were updated to reflect all possible relationships