### PR TITLE
Make cascades optional and templates less redundant

### DIFF
--- a/src/FieldType/Relationship/Generator/DoctrineManyToManyGenerator.php
+++ b/src/FieldType/Relationship/Generator/DoctrineManyToManyGenerator.php
@@ -67,7 +67,8 @@ class DoctrineManyToManyGenerator implements GeneratorInterface
                         ) . $fromVersion,
                         'fromFullyQualifiedClassName' => $sectionConfig
                             ->getFullyQualifiedClassName(),
-                        'toHandle' => $fieldConfig['field']['to'] . $toVersion
+                        'toHandle' => $fieldConfig['field']['to'] . $toVersion,
+                        'cascade' => $fieldConfig['field']['cascade'] ?? false
                     ]
                 )
             );

--- a/src/FieldType/Relationship/Generator/DoctrineManyToOneGenerator.php
+++ b/src/FieldType/Relationship/Generator/DoctrineManyToOneGenerator.php
@@ -57,6 +57,7 @@ class DoctrineManyToOneGenerator implements GeneratorInterface
                         'toHandle' => $toHandle . $toVersion,
                         'toFullyQualifiedClassName' => $to->getConfig()->getFullyQualifiedClassName(),
                         'fromPluralHandle' => Inflector::pluralize((string) $handle) . $fromVersion,
+                        'cascade' => $fieldConfig['field']['cascade'] ?? false
                     ]
                 )
             );

--- a/src/FieldType/Relationship/Generator/DoctrineOneToManyGenerator.php
+++ b/src/FieldType/Relationship/Generator/DoctrineOneToManyGenerator.php
@@ -57,7 +57,8 @@ class DoctrineOneToManyGenerator implements GeneratorInterface
                         'toFullyQualifiedClassName' => $to->getConfig()->getFullyQualifiedClassName(),
                         'fromHandle' => (string) $handle, // Don't version this one, it's mapped to the entity method.
                         'fromPluralHandle' => Inflector::pluralize((string) $handle) . $fromVersion,
-                        'toHandle' => $toHandle . $toVersion
+                        'toHandle' => $toHandle . $toVersion,
+                        'cascade' => $fieldConfig['field']['cascade'] ?? false
                     ]
                 )
             );

--- a/src/FieldType/Relationship/Generator/DoctrineOneToOneGenerator.php
+++ b/src/FieldType/Relationship/Generator/DoctrineOneToOneGenerator.php
@@ -64,7 +64,8 @@ class DoctrineOneToOneGenerator implements GeneratorInterface
                         'toFullyQualifiedClassName' => $to->getConfig()->getFullyQualifiedClassName(),
                         'fromHandle' => $sectionConfig->getHandle() . $fromVersion,
                         'fromFullyQualifiedClassName' => $sectionConfig->getFullyQualifiedClassName(),
-                        'toHandle' => $toHandle . $toVersion
+                        'toHandle' => $toHandle . $toVersion,
+                        'cascade' => $fieldConfig['field']['cascade'] ?? false
                     ]
                 )
             );

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytomany.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytomany.xml.php
@@ -1,9 +1,14 @@
-<?php if ($type === 'unidirectional') { ?>
-<many-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>">
+<many-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>"<?php
+    if ($type === 'bidirectional') {
+        echo ' ' . ($owner ? 'inversed' : 'mapped') . '-by="' . $fromPluralHandle . '"';
+    }?>>
+<?php if ($cascade) { ?>
     <cascade>
-        <cascade-all/>
+        <cascade-<?php echo $cascade; ?> />
     </cascade>
-    <join-table name="<?php echo $fromPluralHandle; ?>_<?php echo $toPluralHandle; ?>">
+<?php } ?>
+<?php if (!($type === 'bidirectional' && !$owner)) { ?>
+    <join-table name="<?php echo $fromPluralHandle . '_' . $toPluralHandle; ?>">
         <join-columns>
             <join-column name="<?php echo $fromHandle; ?>_id" referenced-column-name="id" />
         </join-columns>
@@ -11,25 +16,5 @@
             <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
         </inverse-join-columns>
     </join-table>
+<?php } ?>
 </many-to-many>
-<?php } ?>
-
-<?php if ($type === 'bidirectional' && $owner) { ?>
-<many-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" inversed-by="<?php echo $fromPluralHandle; ?>">
-    <cascade>
-        <cascade-all/>
-    </cascade>
-    <join-table name="<?php echo $fromPluralHandle; ?>_<?php echo $toPluralHandle; ?>">
-        <join-columns>
-            <join-column name="<?php echo $fromHandle; ?>_id" referenced-column-name="id" />
-        </join-columns>
-        <inverse-join-columns>
-            <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
-        </inverse-join-columns>
-    </join-table>
-</many-to-many>
-<?php } ?>
-
-<?php if ($type === 'bidirectional' && !$owner) { ?>
-<many-to-many field="<?php echo $toPluralHandle; ?>" mapped-by="<?php echo $fromPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>"/>
-<?php } ?>

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytoone.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.manytoone.xml.php
@@ -1,11 +1,11 @@
-<?php if ($type === 'bidirectional') { ?>
-<many-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" inversed-by="<?php echo $fromPluralHandle; ?>">
+<many-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>"<?php
+if ($type === 'bidirectional') {
+    echo " inversed-by=\"$fromPluralHandle\"";
+} ?>>
+<?php if ($cascade) { ?>
+    <cascade>
+        <cascade-<?php echo $cascade; ?> />
+    </cascade>
+<?php } ?>
     <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
 </many-to-one>
-<?php } ?>
-
-<?php if ($type === 'unidirectional') { ?>
-<many-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>">
-    <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
-</many-to-one>
-<?php } ?>

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetomany.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetomany.xml.php
@@ -1,1 +1,7 @@
-<one-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" mapped-by="<?php echo $fromHandle; ?>" />
+<one-to-many field="<?php echo $toPluralHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" mapped-by="<?php echo $fromHandle; ?>">
+<?php if ($cascade) { ?>
+    <cascade>
+        <cascade-<?php echo $cascade; ?> />
+    </cascade>
+<?php } ?>
+</one-to-many>

--- a/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetoone.xml.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/doctrine.onetoone.xml.php
@@ -1,15 +1,13 @@
-<?php if ($type === 'bidirectional' && !$owner) { ?>
-<one-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" mapped-by="<?php echo $fromHandle; ?>" />
+<one-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>"<?php
+if ($type === 'bidirectional') {
+    echo ' ' . ($owner ? 'inversed' : 'mapped') . '-by="' . $fromHandle . '"';
+} ?>>
+<?php if ($cascade) { ?>
+    <cascade>
+        <cascade-<?php echo $cascade; ?> />
+    </cascade>
 <?php } ?>
-
-<?php if ($type === 'bidirectional' && $owner) { ?>
-<one-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>" inversed-by="<?php echo $fromHandle; ?>">
+<?php if (!($type === 'bidirectional' && !$owner)) { ?>
     <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
-</one-to-one>
 <?php } ?>
-
-<?php if ($type === 'unidirectional') { ?>
-<one-to-one field="<?php echo $toHandle; ?>" target-entity="<?php echo $toFullyQualifiedClassName; ?>">
-   <join-column name="<?php echo $toHandle; ?>_id" referenced-column-name="id" />
 </one-to-one>
-<?php } ?>

--- a/test/unit/FieldType/Relationship/Generator/DoctrineManyToManyGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/DoctrineManyToManyGeneratorTest.php
@@ -74,7 +74,8 @@ final class DoctrineManyToManyGeneratorTest extends TestCase
                     'owner' => true,
                     'from' => 'this',
                     'to' => 'that',
-                    'type' => 'my type'
+                    'type' => 'my type',
+                    'cascade' => 'all'
                 ]
         ];
         $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
@@ -142,10 +143,9 @@ final class DoctrineManyToManyGeneratorTest extends TestCase
         );
 
         $expected = <<<'EOT'
-
 <many-to-many field="thats_123" target-entity="nameFromSpace\Entity\ToBeMapped" inversed-by="mappers_37">
     <cascade>
-        <cascade-all/>
+        <cascade-all />
     </cascade>
     <join-table name="mappers_37_thats_123">
         <join-columns>
@@ -156,7 +156,6 @@ final class DoctrineManyToManyGeneratorTest extends TestCase
         </inverse-join-columns>
     </join-table>
 </many-to-many>
-
 
 EOT;
 
@@ -249,9 +248,8 @@ EOT;
         );
 
         $expected = <<<'EOT'
-
-
-<many-to-many field="thats_123" mapped-by="mappers_37" target-entity="nameFromSpace\Entity\ToBeMapped"/>
+<many-to-many field="thats_123" target-entity="nameFromSpace\Entity\ToBeMapped" mapped-by="mappers_37">
+</many-to-many>
 
 EOT;
 
@@ -276,7 +274,8 @@ EOT;
                     'owner' => true,
                     'from' => 'this',
                     'to' => 'that',
-                    'type' => 'my type'
+                    'type' => 'my type',
+                    'cascade' => 'persist'
                 ]
         ];
         $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
@@ -346,7 +345,7 @@ EOT;
         $expected = <<<'EOT'
 <many-to-many field="thats_123" target-entity="nameFromSpace\Entity\ToBeMapped">
     <cascade>
-        <cascade-all/>
+        <cascade-persist />
     </cascade>
     <join-table name="mappers_37_thats_123">
         <join-columns>
@@ -357,8 +356,6 @@ EOT;
         </inverse-join-columns>
     </join-table>
 </many-to-many>
-
-
 
 EOT;
 
@@ -452,11 +449,7 @@ EOT;
         );
 
         $expected = <<<'EOT'
-
 <many-to-many field="aliases_123" target-entity="nameFromSpace\Entity\ToBeMapped" inversed-by="mappers_37">
-    <cascade>
-        <cascade-all/>
-    </cascade>
     <join-table name="mappers_37_aliases_123">
         <join-columns>
             <join-column name="mapper_37_id" referenced-column-name="id" />
@@ -466,7 +459,6 @@ EOT;
         </inverse-join-columns>
     </join-table>
 </many-to-many>
-
 
 EOT;
 

--- a/test/unit/FieldType/Relationship/Generator/DoctrineManyToOneGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/DoctrineManyToOneGeneratorTest.php
@@ -145,7 +145,6 @@ class DoctrineManyToOneGeneratorTest extends TestCase
     <join-column name="that_123_id" referenced-column-name="id" />
 </many-to-one>
 
-
 EOT;
 
         $this->assertNotEmpty($generated);
@@ -168,7 +167,8 @@ EOT;
                     'relationship-type' => 'unidirectional',
                     'from' => 'this',
                     'to' => 'that',
-                    'type' => 'not my type'
+                    'type' => 'not my type',
+                    'cascade' => 'delete'
                 ]
         ];
         $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
@@ -236,8 +236,10 @@ EOT;
         );
 
         $expected = <<<'EOT'
-
 <many-to-one field="that_123" target-entity="nameFromSpace\Entity\ToBeMapped">
+    <cascade>
+        <cascade-delete />
+    </cascade>
     <join-column name="that_123_id" referenced-column-name="id" />
 </many-to-one>
 

--- a/test/unit/FieldType/Relationship/Generator/DoctrineOneToManyGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/DoctrineOneToManyGeneratorTest.php
@@ -142,7 +142,8 @@ class DoctrineOneToManyGeneratorTest extends TestCase
         $this->assertInstanceOf(Template::class, $generated);
 
         $expected = <<<EOT
-<one-to-many field="thats_666" target-entity="nameFromSpace\Entity\ToBeMapped" mapped-by="mapper" />
+<one-to-many field="thats_666" target-entity="nameFromSpace\Entity\ToBeMapped" mapped-by="mapper">
+</one-to-many>
 
 EOT;
 
@@ -164,7 +165,8 @@ EOT;
                     'from' => 'this',
                     'to' => 'that',
                     'as' => 'callMeForThat',
-                    'type' => 'not my type'
+                    'type' => 'not my type',
+                    'cascade' => 'all'
                 ]
         ];
         $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
@@ -234,7 +236,11 @@ EOT;
         $this->assertInstanceOf(Template::class, $generated);
 
         $expected = <<<EOT
-<one-to-many field="callMeForThats_666" target-entity="nameFromSpace\Entity\ToBeMapped" mapped-by="mapper" />
+<one-to-many field="callMeForThats_666" target-entity="nameFromSpace\Entity\ToBeMapped" mapped-by="mapper">
+    <cascade>
+        <cascade-all />
+    </cascade>
+</one-to-many>
 
 EOT;
 

--- a/test/unit/FieldType/Relationship/Generator/DoctrineOneToOneGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/DoctrineOneToOneGeneratorTest.php
@@ -80,7 +80,8 @@ final class DoctrineOneToOneGeneratorTest extends TestCase
                     'owner' => true,
                     'from' => 'me',
                     'to' => 'you',
-                    'type' => 'not my type'
+                    'type' => 'not my type',
+                    'cascade' => 'persist'
                 ]
         ];
         $fieldConfig = FieldConfig::fromArray($fieldArrayThing);
@@ -151,11 +152,12 @@ final class DoctrineOneToOneGeneratorTest extends TestCase
         $this->assertInstanceOf(Template::class, $generated);
 
         $expected = <<<EOT
-
 <one-to-one field="you_333" target-entity="namespace\Entity\Handle" inversed-by="niets_37">
+    <cascade>
+        <cascade-persist />
+    </cascade>
     <join-column name="you_333_id" referenced-column-name="id" />
 </one-to-one>
-
 
 EOT;
 
@@ -249,9 +251,8 @@ EOT;
         $this->assertInstanceOf(Template::class, $generated);
 
         $expected = <<<EOT
-<one-to-one field="you_333" target-entity="namespace\Entity\Handle" mapped-by="niets_37" />
-
-
+<one-to-one field="you_333" target-entity="namespace\Entity\Handle" mapped-by="niets_37">
+</one-to-one>
 
 EOT;
 
@@ -345,10 +346,8 @@ EOT;
         $this->assertInstanceOf(Template::class, $generated);
 
         $expected = <<<EOT
-
-
 <one-to-one field="you_333" target-entity="namespace\Entity\Handle">
-   <join-column name="you_333_id" referenced-column-name="id" />
+    <join-column name="you_333_id" referenced-column-name="id" />
 </one-to-one>
 
 EOT;


### PR DESCRIPTION
Cascades now need to be explicitly enabled using `cascade: all`, `cascade: persist` or `cascade: delete`.
The templates are now smaller and don't generate excessive leading or trailing whitespace.
Resolves dionsnoeijen/sexy-field#63, obsoletes #13.