### PR TITLE
Improve FetchFieldsDoctrineSectionReader ORDER_BY handling

### DIFF
--- a/src/SectionField/Service/FetchFieldsDoctrineSectionReader.php
+++ b/src/SectionField/Service/FetchFieldsDoctrineSectionReader.php
@@ -82,7 +82,11 @@ class FetchFieldsDoctrineSectionReader implements ReadSectionInterface
                 function (string $queryField): array {
                     return static::tail(explode(':', $queryField));
                 },
-                array_keys($options[ReadOptions::FIELD])
+                array_merge(
+                    array_keys($options[ReadOptions::FIELD]),
+                    array_key_exists(ReadOptions::ORDER_BY, $options) ?
+                        array_keys($options[ReadOptions::ORDER_BY]) : []
+                )
             )
         );
         $fields = array_unique($fields);
@@ -206,7 +210,10 @@ class FetchFieldsDoctrineSectionReader implements ReadSectionInterface
         }
 
         if (array_key_exists(ReadOptions::ORDER_BY, $options)) {
-            $builder->orderBy(key($options[ReadOptions::ORDER_BY]), current($options[ReadOptions::ORDER_BY]));
+            $builder->orderBy(
+                static::simplifyClass($root) . ':' . key($options[ReadOptions::ORDER_BY]),
+                current($options[ReadOptions::ORDER_BY])
+            );
         }
 
         return $builder;

--- a/test/unit/SectionField/Service/FetchFieldsDoctrineSectionReaderTest.php
+++ b/test/unit/SectionField/Service/FetchFieldsDoctrineSectionReaderTest.php
@@ -31,9 +31,9 @@ final class FetchFieldsDoctrineSectionReaderTest extends TestCase
     {
         $readOptions = ReadOptions::fromArray([
             ReadOptions::SECTION => \TestNS\Product::class,
-            ReadOptions::FETCH_FIELDS => 'slug,prices,price,currency,product',
+            ReadOptions::FETCH_FIELDS => 'slug,price,currency,product',
             ReadOptions::LIMIT => 5,
-            ReadOptions::ORDER_BY => ['product:prices:price' => 'ASC']
+            ReadOptions::ORDER_BY => ['prices:price' => 'ASC']
         ]);
         $expected = static::normalize(<<<'DQL'
             SELECT


### PR DESCRIPTION
- The `ORDER_BY` key doesn't need to contain the root section
- Fields used in `ORDER_BY` are automatically added to `FETCH_FIELDS`